### PR TITLE
fix: fetch wallet NFTs on each update

### DIFF
--- a/hooks/useWalletNFTs.tsx
+++ b/hooks/useWalletNFTs.tsx
@@ -39,7 +39,7 @@ const useWalletNFTs = () => {
     if (publicKey) {
       fetchNFTs()
     }
-  }, [publicKey])
+  })
 
   return { walletNFTs }
 }


### PR DESCRIPTION
Fix refresh issue where wallet NFTs weren't refreshing. The cause is the
`useWalletNFTs` hook was only updating on `publicKey` change instead of
on each update/re-render.