### PR TITLE
Metaplex SDK Migration

### DIFF
--- a/hooks/useGemFarmStaking.ts
+++ b/hooks/useGemFarmStaking.ts
@@ -10,11 +10,13 @@ import { initGemBank } from "lib/gem-farm/common/gem-bank"
 import { GemFarm, initGemFarm } from "lib/gem-farm/common/gem-farm"
 import { getNFTMetadataForMany } from "utils/nfts"
 import { GemBank } from "lib/gem-farm/common/gem-bank"
+import {Metaplex} from "@metaplex-foundation/js";
 
 const useGemFarmStaking = (farmId: string) => {
-  const { connection } = useConnection()
-  const wallet = useAnchorWallet() as SignerWalletAdapter
-  const { walletNFTs, fetchNFTs } = useWalletNFTs()
+  const { connection } = useConnection();
+  const wallet = useAnchorWallet() as SignerWalletAdapter;
+  const { walletNFTs, fetchNFTs } = useWalletNFTs();
+  const metaplex = new Metaplex(connection);
 
   const [farmAccount, setFarmAccount] = useState<any>(null) // @TODO add type to farmAccount
   const [farmerAccount, setFarmerAccount] = useState<any>(null) // @TODO add type to farmerAccount
@@ -122,7 +124,7 @@ const useGemFarmStaking = (farmId: string) => {
           /** Fetch metadatas for Vault NFTs */
           const currentVaultNFTs = await getNFTMetadataForMany(
             mints,
-            connection
+            metaplex
           )
 
           /** Transform to use on the UI */

--- a/hooks/useWalletNFTs.tsx
+++ b/hooks/useWalletNFTs.tsx
@@ -3,28 +3,29 @@ import { programs } from "@metaplex/js"
 import { useCallback, useEffect, useState } from "react"
 import { getNFTsByOwner } from "utils/nfts"
 import { useConnection, useWallet } from "@solana/wallet-adapter-react"
+import {Metaplex} from "@metaplex-foundation/js";
 
 export type NFT = {
   pubkey?: PublicKey
   mint: PublicKey
   onchainMetadata: programs.metadata.MetadataData
   externalMetadata: {
-    attributes: Array<any>
-    collection: any
-    description: string
-    edition: number
-    external_url: string
-    image: string
-    name: string
-    properties: {
-      files: Array<string>
-      category: string
-      creators: Array<{
-        pubKey: string
-        address: string
+    attributes?: Array<any>
+    collection?: any
+    description?: string
+    edition?: number
+    external_url?: string
+    image?: string
+    name?: string
+    properties?: {
+      files?: Array<string>
+      category?: string
+      creators?: Array<{
+        pubKey?: string
+        address?: string
       }>
     }
-    seller_fee_basis_points: number
+    seller_fee_basis_points?: number
   }
 }
 
@@ -34,10 +35,11 @@ const useWalletNFTs = (
 ) => {
   const { connection } = useConnection()
   const { publicKey } = useWallet()
-  const [walletNFTs, setWalletNFTs] = useState<Array<NFT> | null>(null)
+  const [walletNFTs, setWalletNFTs] = useState<Array<NFT> | null>(null);
+  const metaplex = new Metaplex(connection);
 
   const fetchNFTs = useCallback(async () => {
-    const NFTs = await getNFTsByOwner(publicKey, connection)
+    const NFTs = await getNFTsByOwner(publicKey, metaplex);
 
     const filtered = creators
       ? NFTs.filter((NFT) => {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@gemworks/gem-farm-ts": "^0.24.1",
     "@mdx-js/react": "1.6.22",
     "@metaplex/js": "^4.12.0",
+    "@metaplex-foundation/js": "^0.13.3",
     "@solana/wallet-adapter-react": "^0.15.4",
     "@solana/wallet-adapter-react-ui": "^0.9.6",
     "@solana/wallet-adapter-wallets": "^0.15.5",

--- a/utils/nfts.ts
+++ b/utils/nfts.ts
@@ -1,72 +1,44 @@
 import { Connection, PublicKey } from "@solana/web3.js"
-import { TOKEN_PROGRAM_ID } from "@solana/spl-token"
-import axios from "axios"
+import {isLazyNft, Metaplex, Nft} from '@metaplex-foundation/js';
 import { programs } from "@metaplex/js"
-
 import { NFT } from "@/hooks/useWalletNFTs"
 
-const {
-  metadata: { Metadata },
-} = programs
-
-async function getNFTMetadata(
-  mint: string,
-  conn: Connection,
-  pubkey?: string
-): Promise<NFT | undefined> {
-  try {
-    const metadataPDA = await Metadata.getPDA(mint)
-    const onchainMetadata = (await Metadata.load(conn, metadataPDA)).data
-    const externalMetadata = (await axios.get(onchainMetadata.data.uri)).data
-
-    return {
-      pubkey: pubkey ? new PublicKey(pubkey) : undefined,
-      mint: new PublicKey(mint),
-      onchainMetadata,
-      externalMetadata,
+export function matchMetadataWithType(token: Nft): NFT {
+  return {
+    mint: token.mintAddress,
+    onchainMetadata: (token as unknown as programs.metadata.MetadataData),
+    externalMetadata: {
+      image: token.json.image,
+      external_url: token.json.external_url,
+      seller_fee_basis_points: token.json.seller_fee_basis_points,
+      attributes: token.json.attributes,
+      description: token.json.description,
+      collection: token.json.collection,
+      name: token.json.name
     }
-  } catch (e) {
-    console.log(`failed to pull metadata for token ${mint}`)
   }
 }
 
 export async function getNFTMetadataForMany(
-  tokens: any[],
-  conn: Connection
+    tokens: any[],
+    metaplex: Metaplex
 ): Promise<NFT[]> {
-  const promises: Promise<NFT | undefined>[] = []
-  tokens.forEach((token) =>
-    promises.push(getNFTMetadata(token.mint, conn, token.pubkey))
-  )
-  const nfts = (await Promise.all(promises)).filter((n) => !!n)
+  const pubkeys = tokens.map(token => { return new PublicKey(token)});
+  const nfts = await metaplex.nfts().findAllByMintList(pubkeys, { commitment: "confirmed" }).run();
 
-  return nfts
+  return nfts.map(token => {
+    if (isLazyNft(token)) return;
+    return matchMetadataWithType(token);
+  });
 }
 
-/**
- *
- * @author https://github.com/gemworks/gem-farm/tree/main/app/gem-farm
- */
 export async function getNFTsByOwner(
-  owner: PublicKey,
-  conn: Connection
+    owner: PublicKey,
+    metaplex: Metaplex
 ): Promise<NFT[]> {
-  const tokenAccounts = await conn.getParsedTokenAccountsByOwner(owner, {
-    programId: TOKEN_PROGRAM_ID,
-  })
-
-  const tokens = tokenAccounts.value
-    .filter((tokenAccount) => {
-      const amount = tokenAccount.account.data.parsed.info.tokenAmount
-
-      return amount.decimals === 0 && amount.uiAmount === 1
-    })
-    .map((tokenAccount) => {
-      return {
-        pubkey: tokenAccount.pubkey,
-        mint: tokenAccount.account.data.parsed.info.mint,
-      }
-    })
-
-  return await getNFTMetadataForMany(tokens, conn)
+  const nfts = await metaplex.nfts().findAllByOwner(owner, { commitment: "confirmed" }).run();
+  return nfts.map(token => {
+    if (isLazyNft(token)) return;
+    return matchMetadataWithType(token);
+  });
 }


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/gemworks/gem-farm-ui/issues/15), project needs migration to the new Metaplex SDK. 

I've made some changes in utility functions and hooks. To make sure custom 'NFT' type is compatible with new Metaplex types, I had to make some (minor) changes in the type, and make some of the fields optional.